### PR TITLE
fix: discover commands from apps before django.core

### DIFF
--- a/src/management_commands/core.py
+++ b/src/management_commands/core.py
@@ -30,8 +30,8 @@ def import_command_class(dotted_path: str) -> type[BaseCommand]:
 def get_command_paths(name: str, app_label: str | None = None) -> list[str]:
     if not app_label:
         app_names = [
-            "django.core",
             *(app_config.name for app_config in reversed(list(apps.get_app_configs()))),
+            "django.core",
         ]
 
         modules_paths = [f"{module}.{name}.Command" for module in settings.MODULES]


### PR DESCRIPTION
## Linked Issues

Fixes #4.

## Description

In Django, a command registered from the `INSTALLED_APPS` overrides the command from `django.core` if they both have the same name. An example of such a command is `runserver` shipped with `django.contrib.staticfiles`.

This fix preserves this behavior by moving `django.core` to the end of the list of command modules that are checked when discovering commands. As a result, running `runserver` loads the command that is expected to serve static files.

## Checklist

<!-- Remove items that are not applicable. -->

- [x] I have read and followed the project's [Code of Conduct][code-of-conduct] and [Contributing Guide][contributing].
- [x] I have checked that similar PRs have not been created before.
- [x] I have performed a self-review of my code.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

[code-of-conduct]: https://github.com/paduszyk/django-management-commands/blob/main/docs/CODE_OF_CONDUCT.md
[contributing]: https://github.com/paduszyk/django-management-commands/blob/main/docs/CONTRIBUTING.md

