### PR TITLE
feat: implement custom call_command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,18 @@ with:
 from management_commands.management import execute_from_command_line
 ```
 
+If you use `call_command` anywhere in your command, you then need to replace
+
+```python
+from django.core.management import call_command
+```
+
+with:
+
+```python
+from management_commands.management import call_command
+```
+
 That's it! No further steps are needed.
 
 ## Usage
@@ -209,6 +221,7 @@ and `myapp.commands.command` for an app installed from the `myapp` module.
 **Default:** `{}`
 
 Allows the definition of shortcuts or aliases for sequences of Django commands.
+Note: `call_command` does not support aliases.
 
 Example:
 

--- a/src/management_commands/management.py
+++ b/src/management_commands/management.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from typing import Any
 
 from django.core.management import ManagementUtility as BaseManagementUtility
 from django.core.management import call_command as base_call_command
@@ -11,7 +12,7 @@ from .conf import settings
 from .core import import_command_class, load_command_class
 
 if sys.version_info >= (3, 12):
-    from typing import Any, override
+    from typing import override
 else:
     from typing_extensions import override
 


### PR DESCRIPTION
## Linked Issues

Fixes #9 

## Description

Implements custom call_command, which for now I decided not to support aliases in (because the way they are defined is incompatible with call_command)

## Checklist

<!-- Remove items that are not applicable. -->

- [x] I have read and followed the project's [Code of Conduct][code-of-conduct] and [Contributing Guide][contributing].
- [x] I have checked that similar PRs have not been created before.
- [x] I have performed a self-review of my code.
- [x] I have added tests covering my fix or feature implementation.
- [x] I have made corresponding changes to the documentation.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

[code-of-conduct]: https://github.com/paduszyk/django-management-commands/blob/main/docs/CODE_OF_CONDUCT.md
[contributing]: https://github.com/paduszyk/django-management-commands/blob/main/docs/CONTRIBUTING.md
