### PR TITLE
chore(deps): remove pytest-custom-exit-code dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ nox = [
 ]
 pytest = [
   "pytest-cov>=7.1.0",
-  "pytest-custom-exit-code>=0.3.0",
   "pytest-django>=4.11.1",
   "pytest-mock>=3.15.1",
   "pytest-randomly>=4.0.1",
@@ -130,7 +129,6 @@ strict_settings = false
 [tool.pytest.ini_options]
 addopts = [
   "-ra",
-  "--suppress-no-test-exit-code",
   "--ds=tests.settings",
   "--cov",
   "--cov-append",

--- a/uv.lock
+++ b/uv.lock
@@ -820,7 +820,6 @@ dev = [
     { name = "pre-commit", version = "4.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pre-commit", version = "4.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-cov" },
-    { name = "pytest-custom-exit-code" },
     { name = "pytest-django", version = "4.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest-django", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-mock" },
@@ -841,7 +840,6 @@ nox = [
 ]
 pytest = [
     { name = "pytest-cov" },
-    { name = "pytest-custom-exit-code" },
     { name = "pytest-django", version = "4.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest-django", version = "4.14.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "pytest-mock" },
@@ -867,7 +865,6 @@ dev = [
     { name = "nox-uv", specifier = ">=0.7.1" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-custom-exit-code", specifier = ">=0.3.0" },
     { name = "pytest-django", specifier = ">=4.11.1" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-randomly", specifier = ">=4.0.1" },
@@ -880,7 +877,6 @@ nox = [
 ]
 pytest = [
     { name = "pytest-cov", specifier = ">=7.1.0" },
-    { name = "pytest-custom-exit-code", specifier = ">=0.3.0" },
     { name = "pytest-django", specifier = ">=4.11.1" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "pytest-randomly", specifier = ">=4.0.1" },
@@ -1813,19 +1809,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
-]
-
-[[package]]
-name = "pytest-custom-exit-code"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/92/9d/e1eb0af5e96a5c34f59b9aa69dfb680764420fe60f2ec28cfbc5339f99f8/pytest-custom_exit_code-0.3.0.tar.gz", hash = "sha256:51ffff0ee2c1ddcc1242e2ddb2a5fd02482717e33a2326ef330e3aa430244635", size = 3633, upload-time = "2019-08-07T09:45:15.781Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/a0/effb6cbbccfd1c106c572d3d619b3418d71093afb4cd4f91f51e6a1799d2/pytest_custom_exit_code-0.3.0-py3-none-any.whl", hash = "sha256:6e0ce6e57ce3a583cb7e5023f7d1021e19dfec22be41d9ad345bae2fc61caf3b", size = 4055, upload-time = "2019-08-07T09:45:13.767Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Linked Issues

<!-- Use closing keywords if this PR may resolve an existing issue. -->

## Description

Removes the `pytest-custom-exit-code` dependency from the project to streamline testing requirements.

## Checklist

- [ ] I have read and followed the project's [Code of Conduct][code-of-conduct] and [Contributing Guide][contributing].
- [ ] I have checked that similar PRs have not been created before.
- [ ] I have performed a self-review of my code.
- [ ] I have added tests covering my fix or feature implementation.
- [ ] I have made corresponding changes to the documentation.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

[code-of-conduct]: https://github.com/paduszyk/django-management-commands/blob/main/docs/CODE_OF_CONDUCT.md
[contributing]: https://github.com/paduszyk/django-management-commands/blob/main/docs/CONTRIBUTING.md

